### PR TITLE
refactor scored create to use a script for transactions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -44,6 +44,7 @@ func New(config Config) (*Client, error) {
 		newScored = &Scored{
 			pool: config.Pool,
 
+			createScript: nil,
 			updateScript: nil,
 
 			prefix: config.Prefix,

--- a/client/error.go
+++ b/client/error.go
@@ -7,11 +7,20 @@ import (
 	"github.com/xh3b4sd/tracer"
 )
 
-// executionFailedError is an error type for unexpected situations where further
-// code execution cannot continue. This error should never be matched against.
-// Therefore there is no error matcher implemented.
+var alreadyExistsError = &tracer.Error{
+	Kind: "alreadyExistsError",
+}
+
+func IsAlreadyExistsError(err error) bool {
+	return errors.Is(err, alreadyExistsError)
+}
+
 var executionFailedError = &tracer.Error{
 	Kind: "executionFailedError",
+}
+
+func IsExecutionFailedError(err error) bool {
+	return errors.Is(err, executionFailedError)
 }
 
 var invalidConfigError = &tracer.Error{

--- a/client/scored.go
+++ b/client/scored.go
@@ -172,7 +172,7 @@ func (s *Scored) Update(key string, new string, sco float64) (bool, error) {
 				return 1
 			end
 
-			if (old == ARGV[1]) then
+			if (old ~= ARGV[1]) then
 				return 2
 			end
 

--- a/client/scored.go
+++ b/client/scored.go
@@ -31,7 +31,7 @@ func (s *Scored) Create(key string, ele string, sco float64) error {
 				break
 			end
 
-			if (old != "") then
+			if (old ~= "") then
 				return 0
 			end
 
@@ -172,7 +172,7 @@ func (s *Scored) Update(key string, new string, sco float64) (bool, error) {
 				return 1
 			end
 
-			if (old ~= ARGV[1]) then
+			if (old == ARGV[1]) then
 				return 2
 			end
 

--- a/client/scored.go
+++ b/client/scored.go
@@ -8,8 +8,11 @@ import (
 type Scored struct {
 	pool *redis.Pool
 
+	// createScript is internally used to keep track of a script caching
+	// mechanism when creating elements in sorted sets.
+	createScript *redis.Script
 	// updateScript is internally used to keep track of a script caching
-	// mechanism when updating elements of sorted sets.
+	// mechanism when updating elements in sorted sets.
 	updateScript *redis.Script
 
 	prefix string
@@ -19,12 +22,40 @@ func (s *Scored) Create(key string, ele string, sco float64) error {
 	con := s.pool.Get()
 	defer con.Close()
 
-	_, err := redis.Int(con.Do("ZADD", withPrefix(s.prefix, key), sco, ele))
+	if s.createScript == nil {
+		scr := `
+			local old = ""
+			local res = redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[2], ARGV[2])
+			for k, v in pairs(res) do
+				old = v
+				break
+			end
+
+			if (old != "") then
+				return 0
+			end
+
+			redis.call("ZADD", KEYS[1], ARGV[2], ARGV[1])
+
+			return 1
+		`
+
+		s.createScript = redis.NewScript(1, scr)
+	}
+
+	res, err := redis.Int(s.updateScript.Do(con, withPrefix(s.prefix, key), ele, sco))
 	if err != nil {
 		return tracer.Mask(err)
 	}
 
-	return nil
+	switch res {
+	case 0:
+		return tracer.Maskf(alreadyExistsError, "score must be unique")
+	case 1:
+		return nil
+	}
+
+	return tracer.Mask(executionFailedError)
 }
 
 func (s *Scored) Delete(key string, ele string) error {

--- a/client/scored.go
+++ b/client/scored.go
@@ -43,7 +43,7 @@ func (s *Scored) Create(key string, ele string, sco float64) error {
 		s.createScript = redis.NewScript(1, scr)
 	}
 
-	res, err := redis.Int(s.updateScript.Do(con, withPrefix(s.prefix, key), ele, sco))
+	res, err := redis.Int(s.createScript.Do(con, withPrefix(s.prefix, key), ele, sco))
 	if err != nil {
 		return tracer.Mask(err)
 	}

--- a/client/scored_test.go
+++ b/client/scored_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/xh3b4sd/tracer"
 )
 
+func Test_Client_Scored_Create_Error(t *testing.T) {
+	con := redigomock.NewConn()
+	con.Command("EVALSHA", redigomock.NewAnyData(), 1, "prefix:key", "ele", 0.8).Expect(int64(0))
+
+	cli := mustNewClientWithConn(con)
+
+	err := cli.Scored().Create("key", "ele", 0.8)
+	if !errors.Is(err, alreadyExistsError) {
+		t.Fatal("expected", true, "got", false)
+	}
+}
+
+func Test_Client_Scored_Create_Success(t *testing.T) {
+	con := redigomock.NewConn()
+	con.Command("EVALSHA", redigomock.NewAnyData(), 1, "prefix:key", "ele", 0.8).Expect(int64(1))
+
+	cli := mustNewClientWithConn(con)
+
+	err := cli.Scored().Create("key", "ele", 0.8)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func Test_Client_Scored_Delete_Success(t *testing.T) {
 	con := redigomock.NewConn()
 	con.Command("ZREM", "prefix:test-key", "test-element").Expect(int64(1))
@@ -291,5 +315,20 @@ func Test_Client_Scored_Search_Redis_Valid(t *testing.T) {
 	}
 	if values[1] != "two" {
 		t.Fatal("expected", "two", "got", values[1])
+	}
+}
+
+func Test_Client_Scored_Update_Call(t *testing.T) {
+	con := redigomock.NewConn()
+	con.Command("EVALSHA", redigomock.NewAnyData(), 1, "prefix:key", "ele", 0.8).Expect(int64(3))
+
+	cli := mustNewClientWithConn(con)
+
+	upd, err := cli.Scored().Update("key", "ele", 0.8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !upd {
+		t.Fatal(err)
 	}
 }

--- a/client/scored_test.go
+++ b/client/scored_test.go
@@ -10,30 +10,6 @@ import (
 	"github.com/xh3b4sd/tracer"
 )
 
-func Test_Client_Scored_Create_Success(t *testing.T) {
-	con := redigomock.NewConn()
-	con.Command("ZADD", "prefix:key", 0.8, "element").Expect(int64(1))
-
-	cli := mustNewClientWithConn(con)
-
-	err := cli.Scored().Create("key", "element", 0.8)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func Test_Client_Scored_Create_Error(t *testing.T) {
-	con := redigomock.NewConn()
-	con.Command("ZADD", "prefix:key", 0.8, "element").ExpectError(executionFailedError)
-
-	cli := mustNewClientWithConn(con)
-
-	err := cli.Scored().Create("key", "element", 0.8)
-	if !errors.Is(err, executionFailedError) {
-		t.Fatal("expected", true, "got", false)
-	}
-}
-
 func Test_Client_Scored_Delete_Success(t *testing.T) {
 	con := redigomock.NewConn()
 	con.Command("ZREM", "prefix:test-key", "test-element").Expect(int64(1))


### PR DESCRIPTION
There are no automated tests for ensuring the integrity of the transaction implemented here. Though I had some real world application using this where the score was the unix timestamp in seconds. When I fire up two requests against that API, one succeeds and the other fails as expected. 

```
$ grpcurl -d '{"obj":{"metadata":{"timeline.venturemark.co/id":"1606396471","user.venturemark.co/id":"usr-al9qy"},"property":{"data":[{"space":"y","value":[23]}],"text":"foo bar baz"}}}' -plaintext 127.0.0.1:7777 metupd.API.Create
{
  "obj": {
    "metadata": {
      "metric.venturemark.co/id": "1606480943",
      "update.venturemark.co/id": "1606480943"
    }
  }
}
```



```
$ grpcurl -d '{"obj":{"metadata":{"timeline.venturemark.co/id":"1606396471","user.venturemark.co/id":"usr-al9qy"},"property":{"data":[{"space":"y","value":[23]}],"text":"foo bar baz"}}}' -plaintext 127.0.0.1:7777 metupd.API.Create
ERROR:
  Code: Unknown
  Message: score must be unique
```